### PR TITLE
Update type checking to use type.prototype

### DIFF
--- a/lib/ElementPropTypes.js
+++ b/lib/ElementPropTypes.js
@@ -73,7 +73,7 @@ function createChainableTypeChecker(validate) {
 function createElementTypeChecker(ExpectedElementType) {
     function validate(props, propName, componentName, location, propFullName) {
         var prop = props[propName];
-        if (prop && prop.type !== ExpectedElementType) {
+        if (prop && prop.type.prototype instanceof ExpectedElementType) {
             var locationName = ReactPropTypeLocationNames[location];
             var expectedElementTypeName = getDisplayName(ExpectedElementType);
 


### PR DESCRIPTION
I am using React v16.4.0 and the type checking failed.
Please refer to https://stackoverflow.com/questions/27366077/only-allow-children-of-a-specific-type-in-a-react-component#comment77051167_36424582 for more details.

```
console.log(child.type, child.type == MyTab); // false
console.log(child.type, child.type.prototype instanceof MyTab) // true
```